### PR TITLE
Feature/disable nginx logs

### DIFF
--- a/docker/server/nginx/nginx.conf
+++ b/docker/server/nginx/nginx.conf
@@ -3,6 +3,10 @@ server {
   server_name conductor;
   server_tokens off;
 
+  # Redirect logs to stdout and stderr
+  access_log /dev/stdout;
+  error_log /dev/stderr;
+
   location / {
     add_header Referrer-Policy "strict-origin";
     add_header X-Frame-Options "SAMEORIGIN";

--- a/docker/server/nginx/nginx.conf
+++ b/docker/server/nginx/nginx.conf
@@ -4,8 +4,7 @@ server {
   server_tokens off;
 
   # Redirect logs to stdout and stderr
-  access_log /dev/stdout;
-  error_log /dev/stderr;
+  access_log off;
 
   location / {
     add_header Referrer-Policy "strict-origin";


### PR DESCRIPTION
Pull Request type
----
- [x] Other (please describe):

Disable saving nginx access logs to disk. The logs grow and eventually cause pod eviction due to running out of ephemeral storage.